### PR TITLE
Remove duplicate script tag from index page

### DIFF
--- a/casinoApp/web/index.html
+++ b/casinoApp/web/index.html
@@ -21,6 +21,5 @@
     </div>
     <div id="status">Готов к ставке</div>
   </div>
-  <script src="./app.js"></script> <!-- ← добавили JS -->
 </body>
 </html>


### PR DESCRIPTION
## Summary
- remove redundant script tag from `web/index.html` leaving only the deferred script in the head

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a85db51558832a8315a1c77055f9c9