### PR TITLE
feat: show bet choice separately

### DIFF
--- a/casinoApp/web/app.js
+++ b/casinoApp/web/app.js
@@ -12,10 +12,11 @@ async function init() {
   // -------- DOM ----------
   const cvs = document.getElementById('canvas');
   const ctx = cvs.getContext('2d');
-  const statusEl = document.getElementById('status');
-  const controls = document.getElementById('controls');
-  const btnUp = document.getElementById('btn-up');
-  const btnDown = document.getElementById('btn-down');
+    const statusEl = document.getElementById('status');
+    const choiceEl = document.getElementById('choice');
+    const controls = document.getElementById('controls');
+    const btnUp = document.getElementById('btn-up');
+    const btnDown = document.getElementById('btn-down');
 
   // -------- размеры ----------
   function sizeCanvas() {
@@ -204,18 +205,18 @@ async function init() {
     return res.json();
   }
 
-  btnUp.addEventListener('click', async () => {
-    const r = await fetch('/api/rounds/bet', { method: 'POST' });
-    const j = await r.json();
-    controls.style.display = 'none';
-    statusEl.textContent = j.ok ? 'Вы выбрали: 📈 Вверх' : 'Приём ставок закрыт';
-  });
-  btnDown.addEventListener('click', async () => {
-    const r = await fetch('/api/rounds/bet', { method: 'POST' });
-    const j = await r.json();
-    controls.style.display = 'none';
-    statusEl.textContent = j.ok ? 'Вы выбрали: 📉 Вниз' : 'Приём ставок закрыт';
-  });
+    btnUp.addEventListener('click', async () => {
+      const r = await fetch('/api/rounds/bet', { method: 'POST' });
+      const j = await r.json();
+      controls.style.display = 'none';
+      choiceEl.textContent = j.ok ? 'Вы выбрали: 📈 Вверх' : 'Приём ставок закрыт';
+    });
+    btnDown.addEventListener('click', async () => {
+      const r = await fetch('/api/rounds/bet', { method: 'POST' });
+      const j = await r.json();
+      controls.style.display = 'none';
+      choiceEl.textContent = j.ok ? 'Вы выбрали: 📉 Вниз' : 'Приём ставок закрыт';
+    });
 
   // ===== опрос состояния раунда =====
   let lastRoundId = null;
@@ -235,13 +236,14 @@ async function init() {
         paused = false;
         bias = 0;
 
-        controls.style.display = 'flex';
+          controls.style.display = 'flex';
+          choiceEl.textContent = '';
 
-        [targetMin, targetMax] = recomputeTargetScale();
-        viewMin = targetMin;
-        viewMax = targetMax;
+          [targetMin, targetMax] = recomputeTargetScale();
+          viewMin = targetMin;
+          viewMax = targetMax;
 
-        statusEl.textContent = `Новый раунд #${st.id}`;
+          statusEl.textContent = `Новый раунд #${st.id}`;
       }
 
       if (st.status === 'betting') {

--- a/casinoApp/web/index.html
+++ b/casinoApp/web/index.html
@@ -10,16 +10,17 @@
 
 </head>
 <body>
-  <div id="app">
-    <h1>Куда пойдёт график?</h1>
-    <div id="chart">
+    <div id="app">
+      <h1>Куда пойдёт график?</h1>
+      <div id="chart">
         <canvas id="canvas" width="900" height="420"></canvas>
+      </div>
+      <div id="controls">
+        <button id="btn-up">📈 Вверх</button>
+        <button id="btn-down">📉 Вниз</button>
+      </div>
+      <div id="status">Готов к ставке</div>
+      <div id="choice"></div>
     </div>
-    <div id="controls">
-      <button id="btn-up">📈 Вверх</button>
-      <button id="btn-down">📉 Вниз</button>
-    </div>
-    <div id="status">Готов к ставке</div>
-  </div>
-</body>
+  </body>
 </html>

--- a/casinoApp/web/style.css
+++ b/casinoApp/web/style.css
@@ -45,7 +45,12 @@ html, body {
 #btn-up   { background: #1f9d55; color: #fff; }
 #btn-down { background: #e53e3e; color: #fff; }
 
-#status {
+#status,
+#choice {
   opacity: .9;
   font-size: 14px;
+}
+
+#choice {
+  margin-top: 4px;
 }


### PR DESCRIPTION
## Summary
- add dedicated choice element to display selected bet
- style choice element similarly to status
- update app logic to show bet in choice and clear it on new round

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a86e711b78832a966a5185c55da576